### PR TITLE
chore: Standardize project naming to CodeVerse Linux

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for helping improve CVH Linux.
+        Thanks for helping improve CodeVerse Linux.
 
   - type: textarea
     id: problem

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for contributing to CodeVerse Linux (CVH Linux).
+Thanks for contributing to CodeVerse Linux (CodeVerse Linux).
 
 ## Setup (build environment)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# CodeVerse Linux (CVH Linux)
+# CodeVerse Linux (CodeVerse Linux)
 
-CodeVerse Linux (CVH Linux) is a **community-driven, Arch-based Linux distribution** with a **Wayland-first** focus. The repository contains an **ArchISO profile** (`iso/`), build tooling (`scripts/`), curated configs (`configs/`), and a small set of custom packages (`src/`, `pkgbuild/`, `repo/`).
+CodeVerse Linux (CodeVerse Linux) is a **community-driven, Arch-based Linux distribution** with a **Wayland-first** focus. The repository contains an **ArchISO profile** (`iso/`), build tooling (`scripts/`), curated configs (`configs/`), and a small set of custom packages (`src/`, `pkgbuild/`, `repo/`).
 
 ## Target
 

--- a/configs/grub/themes/cvh-nordic/theme.txt
+++ b/configs/grub/themes/cvh-nordic/theme.txt
@@ -1,4 +1,4 @@
-# CVH Linux Nordic GRUB Theme
+# CodeVerse Linux Nordic GRUB Theme
 # Nord Color Palette
 
 # Desktop

--- a/configs/setup-configs/niri/Sub-configs/animations.kdl
+++ b/configs/setup-configs/niri/Sub-configs/animations.kdl
@@ -1,7 +1,7 @@
 // The wiki explains how to configure individual animations:
 // https://yalter.github.io/niri/Configuration:-Animations
 
-// Currently no animations are being added as of early release of codeverse linux.
+// Currently no animations are being added as of early release of CodeVerse Linux.
 // You can add your own by referring to the wiki link mentioned at the top.
 
 animations {

--- a/configs/setup-configs/rofi/scripts/codeverse-menu.sh
+++ b/configs/setup-configs/rofi/scripts/codeverse-menu.sh
@@ -4,7 +4,7 @@ SCRIPTS_DIR="$HOME/.config/rofi/scripts"
 
 # // --  If no argument is provided, list the options -- //
 if [ -z "$@" ]; then
-    echo -en "\0prompt\x1fCVH Linux\n"
+    echo -en "\0prompt\x1fCodeVerse Linux\n"
     echo -en "󰣆  Applications\n"
     echo -en "󰖯  Windows\n"
     echo -en "󰸉  Wallpaper Selector\n"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-CVH Linux is assembled as an ArchISO profile with a small set of custom packages and synced user/system configuration.
+CodeVerse Linux is assembled as an ArchISO profile with a small set of custom packages and synced user/system configuration.
 
 ## Key directories
 

--- a/iso/airootfs/etc/mkinitcpio.conf
+++ b/iso/airootfs/etc/mkinitcpio.conf
@@ -1,4 +1,4 @@
-# CVH Linux Live ISO mkinitcpio configuration
+# CodeVerse Linux Live ISO mkinitcpio configuration
 # vim: set ft=sh:
 
 MODULES=()

--- a/iso/airootfs/etc/pacman.conf
+++ b/iso/airootfs/etc/pacman.conf
@@ -1,5 +1,5 @@
 #
-# CVH Linux Live Environment Pacman Configuration
+# CodeVerse Linux Live Environment Pacman Configuration
 #
 
 [options]

--- a/iso/airootfs/etc/rc.conf
+++ b/iso/airootfs/etc/rc.conf
@@ -1,4 +1,4 @@
-# CVH Linux OpenRC Configuration
+# CodeVerse Linux OpenRC Configuration
 # /etc/rc.conf
 
 # Enable Unicode support

--- a/iso/airootfs/etc/skel/.config/niri/config.kdl
+++ b/iso/airootfs/etc/skel/.config/niri/config.kdl
@@ -1,4 +1,4 @@
-// CVH Linux Niri Configuration
+// CodeVerse Linux Niri Configuration
 // Minimal, lightweight Wayland compositor setup
 
 // Input configuration

--- a/iso/airootfs/etc/skel/.zshrc
+++ b/iso/airootfs/etc/skel/.zshrc
@@ -1,4 +1,4 @@
-# CVH Linux Zsh Configuration
+# CodeVerse Linux Zsh Configuration
 
 # Path to Oh My Zsh installation
 export ZSH="$HOME/.oh-my-zsh"
@@ -99,7 +99,7 @@ alias ..='cd ..'
 alias ...='cd ../..'
 alias ....='cd ../../..'
 
-# CVH Linux aliases
+# CodeVerse Linux aliases
 alias ff='cvh-fuzzy'
 alias ffa='cvh-fuzzy --mode apps'
 alias fff='cvh-fuzzy --mode files'

--- a/iso/airootfs/root/.zshrc
+++ b/iso/airootfs/root/.zshrc
@@ -1,4 +1,4 @@
-# CVH Linux Live Environment
+# CodeVerse Linux Live Environment
 
 # Basic prompt
 PS1='%F{cyan}[CVH Live]%f %F{green}%n@%m%f:%F{blue}%~%f %# '
@@ -10,8 +10,8 @@ alias install='cvh-install'
 
 # Welcome message
 echo ""
-echo "  Welcome to CVH Linux Live Environment!"
+echo "  Welcome to CodeVerse Linux Live Environment!"
 echo ""
-echo "  To install CVH Linux, run: cvh-install"
+echo "  To install CodeVerse Linux, run: cvh-install"
 echo "  To start Niri compositor, run: niri-session"
 echo ""

--- a/iso/airootfs/usr/bin/cvh-install
+++ b/iso/airootfs/usr/bin/cvh-install
@@ -1,7 +1,7 @@
 #!/bin/bash
-# CVH Linux Installer
-# Modular installer for CVH Linux distribution
-# Run from live environment to install CVH Linux to disk
+# CodeVerse Linux Installer
+# Modular installer for CodeVerse Linux distribution
+# Run from live environment to install CodeVerse Linux to disk
 
 set -o pipefail
 

--- a/iso/airootfs/usr/lib/cvh-install/config.sh
+++ b/iso/airootfs/usr/lib/cvh-install/config.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# CVH Linux Installer - Configuration Module
+# CodeVerse Linux Installer - Configuration Module
 # Global variables and defaults
 
 # Progress tracking
@@ -18,7 +18,7 @@ export HOSTNAME="cvh-linux"
 export TIMEZONE="Asia/Jerusalem"
 export LOCALE="en_US.UTF-8"
 export KEYMAP="us"
-export COMPOSITOR="niri"  # CVH Linux uses niri compositor
+export COMPOSITOR="niri"  # CodeVerse Linux uses niri compositor
 
 # Package lists - synced with packages.x86_64
 # Note: archiso-specific packages (mkinitcpio-archiso, nbd, etc.) are excluded

--- a/iso/airootfs/usr/lib/cvh-install/configure.sh
+++ b/iso/airootfs/usr/lib/cvh-install/configure.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# CVH Linux Installer - Configure Module
+# CodeVerse Linux Installer - Configure Module
 # System configuration functions
 
 # Configure the installed system
@@ -110,7 +110,7 @@ EOF
 # Configure Ly display manager
 mkdir -p /etc/ly
 cat > /etc/ly/config.ini << 'LY_EOF'
-# CVH Linux Ly Configuration
+# CodeVerse Linux Ly Configuration
 
 # Disable the doom-fire background animation
 animate = false
@@ -165,8 +165,8 @@ fi
 
 # Create os-release for proper branding (GRUB uses this)
 cat > /etc/os-release << EOF
-NAME="CVH Linux"
-PRETTY_NAME="CVH Linux"
+NAME="CodeVerse Linux"
+PRETTY_NAME="CodeVerse Linux"
 ID=cvh
 ID_LIKE=arch
 BUILD_ID=rolling
@@ -177,8 +177,8 @@ LOGO=cvh-logo
 EOF
 
 # Set GRUB distributor name
-sed -i 's/^GRUB_DISTRIBUTOR=.*/GRUB_DISTRIBUTOR="CVH Linux"/' /etc/default/grub 2>/dev/null || \
-    echo 'GRUB_DISTRIBUTOR="CVH Linux"' >> /etc/default/grub
+sed -i 's/^GRUB_DISTRIBUTOR=.*/GRUB_DISTRIBUTOR="CodeVerse Linux"/' /etc/default/grub 2>/dev/null || \
+    echo 'GRUB_DISTRIBUTOR="CodeVerse Linux"' >> /etc/default/grub
 
 # Install Tela GRUB theme
 if [[ -d /usr/share/cvh-linux/grub-theme/tela ]]; then

--- a/iso/airootfs/usr/lib/cvh-install/detect.sh
+++ b/iso/airootfs/usr/lib/cvh-install/detect.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# CVH Linux Installer - Detection Module
+# CodeVerse Linux Installer - Detection Module
 # System detection functions
 
 # Detect boot mode (UEFI or BIOS)

--- a/iso/airootfs/usr/lib/cvh-install/disk.sh
+++ b/iso/airootfs/usr/lib/cvh-install/disk.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# CVH Linux Installer - Disk Module
+# CodeVerse Linux Installer - Disk Module
 # Disk partitioning and formatting functions
 
 # Partition the disk

--- a/iso/airootfs/usr/lib/cvh-install/finalize.sh
+++ b/iso/airootfs/usr/lib/cvh-install/finalize.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# CVH Linux Installer - Finalize Module
+# CodeVerse Linux Installer - Finalize Module
 # Password setting, cleanup, and reboot
 
 # Set passwords

--- a/iso/airootfs/usr/lib/cvh-install/input.sh
+++ b/iso/airootfs/usr/lib/cvh-install/input.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# CVH Linux Installer - Input Module
+# CodeVerse Linux Installer - Input Module
 # User input and selection functions
 
 # Select keyboard layout
@@ -41,7 +41,7 @@ select_timezone() {
 select_compositor() {
     step_header "Compositor"
 
-    # CVH Linux uses niri as the default compositor
+    # CodeVerse Linux uses niri as the default compositor
     COMPOSITOR="niri"
 
     echo -e "\n  ${GREEN}✓${NC} Compositor: ${BOLD}$COMPOSITOR${NC} (scrollable-tiling)"

--- a/iso/airootfs/usr/lib/cvh-install/packages.sh
+++ b/iso/airootfs/usr/lib/cvh-install/packages.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# CVH Linux Installer - Packages Module
+# CodeVerse Linux Installer - Packages Module
 # Package installation functions
 
 # Install base system
@@ -58,7 +58,7 @@ create_mirrorlist() {
     gum style --foreground 6 "  ● Creating package mirrorlist..."
     mkdir -p /mnt/etc/pacman.d
     cat > /mnt/etc/pacman.d/mirrorlist << 'EOF'
-# Arch Linux mirrorlist - CVH Linux
+# Arch Linux mirrorlist - CodeVerse Linux
 # Israeli mirrors
 Server = https://mirror.isoc.org.il/pub/archlinux/$repo/os/$arch
 Server = https://archlinux.mivzakim.net/$repo/os/$arch

--- a/iso/airootfs/usr/lib/cvh-install/ui.sh
+++ b/iso/airootfs/usr/lib/cvh-install/ui.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# CVH Linux Installer - UI Module
+# CodeVerse Linux Installer - UI Module
 
 # Logging functions using gum
 log_info() { gum log --level info "$1"; }
@@ -72,5 +72,5 @@ show_completion() {
         --foreground 82 --border-foreground 82 --border double \
         --align center --width 60 --margin "1 2" --padding "1 4" \
         "✓ Installation Complete!" "" \
-        "CVH Linux has been installed successfully."
+        "CodeVerse Linux has been installed successfully."
 }

--- a/iso/grub/grub.cfg
+++ b/iso/grub/grub.cfg
@@ -1,4 +1,4 @@
-# CVH Linux GRUB Configuration
+# CodeVerse Linux GRUB Configuration
 
 set default=0
 set timeout=5
@@ -30,25 +30,25 @@ set color_normal=white/black
 set color_highlight=cyan/black
 
 # Menu entries
-menuentry "CVH Linux (Live)" --class cvh --class gnu-linux --class os {
+menuentry "CodeVerse Linux (Live)" --class cvh --class gnu-linux --class os {
     set gfxpayload=keep
     linux /cvh/boot/x86_64/vmlinuz-linux archisobasedir=cvh archisolabel=%ARCHISO_LABEL% quiet splash
     initrd /cvh/boot/x86_64/initramfs-linux.img
 }
 
-menuentry "CVH Linux (Live, Copy to RAM)" --class cvh --class gnu-linux --class os {
+menuentry "CodeVerse Linux (Live, Copy to RAM)" --class cvh --class gnu-linux --class os {
     set gfxpayload=keep
     linux /cvh/boot/x86_64/vmlinuz-linux archisobasedir=cvh archisolabel=%ARCHISO_LABEL% copytoram=y quiet splash
     initrd /cvh/boot/x86_64/initramfs-linux.img
 }
 
-menuentry "CVH Linux (Live, Safe Graphics)" --class cvh --class gnu-linux --class os {
+menuentry "CodeVerse Linux (Live, Safe Graphics)" --class cvh --class gnu-linux --class os {
     set gfxpayload=keep
     linux /cvh/boot/x86_64/vmlinuz-linux archisobasedir=cvh archisolabel=%ARCHISO_LABEL% nomodeset quiet
     initrd /cvh/boot/x86_64/initramfs-linux.img
 }
 
-menuentry "CVH Linux (Live, Verbose Boot)" --class cvh --class gnu-linux --class os {
+menuentry "CodeVerse Linux (Live, Verbose Boot)" --class cvh --class gnu-linux --class os {
     set gfxpayload=keep
     linux /cvh/boot/x86_64/vmlinuz-linux archisobasedir=cvh archisolabel=%ARCHISO_LABEL%
     initrd /cvh/boot/x86_64/initramfs-linux.img

--- a/iso/grub/themes/cvh-nordic/theme.txt
+++ b/iso/grub/themes/cvh-nordic/theme.txt
@@ -1,4 +1,4 @@
-# CVH Linux Nordic GRUB Theme
+# CodeVerse Linux Nordic GRUB Theme
 # Nord Color Palette
 
 # Desktop

--- a/iso/packages.x86_64
+++ b/iso/packages.x86_64
@@ -1,4 +1,4 @@
-# CVH Linux Package List
+# CodeVerse Linux Package List
 # Minimal lightweight Arch-based distro
 
 # =============================================================================
@@ -210,7 +210,7 @@ gcc
 pkgconf
 
 # =============================================================================
-# CVH LINUX CUSTOM PACKAGES (from cvh-linux repo)
+# CodeVerse Linux CUSTOM PACKAGES (from cvh-linux repo)
 # =============================================================================
 cvh-fuzzy
 cvh-icons

--- a/iso/pacman.conf
+++ b/iso/pacman.conf
@@ -1,4 +1,4 @@
-# CVH Linux Pacman Configuration
+# CodeVerse Linux Pacman Configuration
 # Using standard Arch Linux repositories
 
 [options]
@@ -24,7 +24,7 @@ Server = https://archlinux.mivzakim.net/$repo/os/$arch
 Server = https://geo.mirror.pkgbuild.com/$repo/os/$arch
 Server = https://mirrors.kernel.org/archlinux/$repo/os/$arch
 
-# CVH Linux custom repository
+# CodeVerse Linux custom repository
 [cvh-linux]
 SigLevel = Optional TrustAll
 # GitHub (primary)

--- a/iso/profiledef.sh
+++ b/iso/profiledef.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# CVH Linux ISO Profile Definition
+# CodeVerse Linux ISO Profile Definition
 # Based on archiso profile format
 
 iso_name="cvh-linux"
 iso_label="CVH_LINUX_$(date +%Y%m)"
 iso_publisher="CodeVerse Hub <https://codeversehub.dev>"
-iso_application="CVH Linux Live/Install ISO"
+iso_application="CodeVerse Linux Live/Install ISO"
 iso_version="$(date +%Y.%m.%d)"
 install_dir="cvh"
 buildmodes=('iso')

--- a/iso/syslinux/syslinux.cfg
+++ b/iso/syslinux/syslinux.cfg
@@ -1,4 +1,4 @@
-# CVH Linux Syslinux Configuration
+# CodeVerse Linux Syslinux Configuration
 
 DEFAULT cvh
 PROMPT 0
@@ -6,7 +6,7 @@ TIMEOUT 50
 
 UI vesamenu.c32
 
-MENU TITLE CVH Linux Boot Menu
+MENU TITLE CodeVerse Linux Boot Menu
 MENU RESOLUTION 1024 768
 MENU COLOR border       30;44   #40ffffff #a0000000 std
 MENU COLOR title        1;36;44 #9033ccff #a0000000 std
@@ -19,25 +19,25 @@ MENU COLOR msg07        37;40   #90ffffff #a0000000 std
 MENU COLOR tabmsg       31;40   #30ffffff #00000000 std
 
 LABEL cvh
-MENU LABEL CVH Linux (Live)
+MENU LABEL CodeVerse Linux (Live)
 LINUX /cvh/boot/x86_64/vmlinuz-linux
 INITRD /cvh/boot/x86_64/initramfs-linux.img
 APPEND archisobasedir=cvh archisolabel=%ARCHISO_LABEL% quiet splash
 
 LABEL cvh-copytoram
-MENU LABEL CVH Linux (Live, Copy to RAM)
+MENU LABEL CodeVerse Linux (Live, Copy to RAM)
 LINUX /cvh/boot/x86_64/vmlinuz-linux
 INITRD /cvh/boot/x86_64/initramfs-linux.img
 APPEND archisobasedir=cvh archisolabel=%ARCHISO_LABEL% copytoram=y quiet splash
 
 LABEL cvh-safe
-MENU LABEL CVH Linux (Live, Safe Graphics)
+MENU LABEL CodeVerse Linux (Live, Safe Graphics)
 LINUX /cvh/boot/x86_64/vmlinuz-linux
 INITRD /cvh/boot/x86_64/initramfs-linux.img
 APPEND archisobasedir=cvh archisolabel=%ARCHISO_LABEL% nomodeset quiet
 
 LABEL cvh-verbose
-MENU LABEL CVH Linux (Live, Verbose Boot)
+MENU LABEL CodeVerse Linux (Live, Verbose Boot)
 LINUX /cvh/boot/x86_64/vmlinuz-linux
 INITRD /cvh/boot/x86_64/initramfs-linux.img
 APPEND archisobasedir=cvh archisolabel=%ARCHISO_LABEL%

--- a/pkgbuild/cvh-branding/PKGBUILD
+++ b/pkgbuild/cvh-branding/PKGBUILD
@@ -1,8 +1,8 @@
-# Maintainer: CVH Linux Team
+# Maintainer: CodeVerse Linux Team
 pkgname=cvh-branding
 pkgver=0.1.0
 pkgrel=1
-pkgdesc="CVH Linux branding, GRUB theme, and default configurations"
+pkgdesc="CodeVerse Linux branding, GRUB theme, and default configurations"
 arch=('any')
 url="https://github.com/codeversehub/cvh-linux"
 license=('GPL3')
@@ -14,7 +14,7 @@ _cvh_root="/home/ofekb/codeversedistro/CodeVerseLinuxDistro"
 package() {
     # MOTD - welcome message
     install -Dm644 /dev/stdin "$pkgdir/etc/motd" <<'MOTDEOF'
-Welcome to CVH Linux!
+Welcome to CodeVerse Linux!
 
 Quick Start:
   - Mod+Return    Open terminal
@@ -26,10 +26,10 @@ Quick Start:
 For more info: https://github.com/codeversehub/cvh-linux
 MOTDEOF
 
-    # CVH Linux info file
+    # CodeVerse Linux info file
     install -Dm644 /dev/stdin "$pkgdir/usr/share/cvh-linux/info" <<'INFOEOF'
-NAME="CVH Linux"
-PRETTY_NAME="CVH Linux"
+NAME="CodeVerse Linux"
+PRETTY_NAME="CodeVerse Linux"
 ID=cvh
 VERSION_ID=0.1
 HOME_URL="https://codeversehub.dev"

--- a/pkgbuild/cvh-branding/pkg/cvh-branding/.PKGINFO
+++ b/pkgbuild/cvh-branding/pkg/cvh-branding/.PKGINFO
@@ -4,7 +4,7 @@ pkgname = cvh-branding
 pkgbase = cvh-branding
 xdata = pkgtype=pkg
 pkgver = 0.1.0-1
-pkgdesc = CVH Linux branding, GRUB theme, and default configurations
+pkgdesc = CodeVerse Linux branding, GRUB theme, and default configurations
 url = https://github.com/codeversehub/cvh-linux
 builddate = 1770221580
 packager = Unknown Packager

--- a/pkgbuild/cvh-branding/pkg/cvh-branding/etc/motd
+++ b/pkgbuild/cvh-branding/pkg/cvh-branding/etc/motd
@@ -1,4 +1,4 @@
-Welcome to CVH Linux!
+Welcome to CodeVerse Linux!
 
 Quick Start:
   - Mod+Return    Open terminal

--- a/pkgbuild/cvh-branding/pkg/cvh-branding/usr/share/cvh-linux/info
+++ b/pkgbuild/cvh-branding/pkg/cvh-branding/usr/share/cvh-linux/info
@@ -1,5 +1,5 @@
-NAME="CVH Linux"
-PRETTY_NAME="CVH Linux"
+NAME="CodeVerse Linux"
+PRETTY_NAME="CodeVerse Linux"
 ID=cvh
 VERSION_ID=0.1
 HOME_URL="https://codeversehub.dev"

--- a/pkgbuild/cvh-fuzzy/PKGBUILD
+++ b/pkgbuild/cvh-fuzzy/PKGBUILD
@@ -1,8 +1,8 @@
-# Maintainer: CVH Linux Team
+# Maintainer: CodeVerse Linux Team
 pkgname=cvh-fuzzy
 pkgver=0.1.0
 pkgrel=1
-pkgdesc="Universal fuzzy finder for CVH Linux"
+pkgdesc="Universal fuzzy finder for CodeVerse Linux"
 arch=('x86_64')
 url="https://github.com/codeversehub/cvh-linux"
 license=('GPL3')

--- a/pkgbuild/cvh-fuzzy/pkg/cvh-fuzzy/.PKGINFO
+++ b/pkgbuild/cvh-fuzzy/pkg/cvh-fuzzy/.PKGINFO
@@ -4,7 +4,7 @@ pkgname = cvh-fuzzy
 pkgbase = cvh-fuzzy
 xdata = pkgtype=pkg
 pkgver = 0.1.0-1
-pkgdesc = Universal fuzzy finder for CVH Linux
+pkgdesc = Universal fuzzy finder for CodeVerse Linux
 url = https://github.com/codeversehub/cvh-linux
 builddate = 1770221576
 packager = Unknown Packager

--- a/pkgbuild/cvh-icons/PKGBUILD
+++ b/pkgbuild/cvh-icons/PKGBUILD
@@ -1,8 +1,8 @@
-# Maintainer: CVH Linux Team
+# Maintainer: CodeVerse Linux Team
 pkgname=cvh-icons
 pkgver=0.1.0
 pkgrel=1
-pkgdesc="Sandboxed Lua-scriptable desktop icons for CVH Linux"
+pkgdesc="Sandboxed Lua-scriptable desktop icons for CodeVerse Linux"
 arch=('x86_64')
 url="https://github.com/codeversehub/cvh-linux"
 license=('GPL3')

--- a/pkgbuild/cvh-icons/pkg/cvh-icons/.PKGINFO
+++ b/pkgbuild/cvh-icons/pkg/cvh-icons/.PKGINFO
@@ -4,7 +4,7 @@ pkgname = cvh-icons
 pkgbase = cvh-icons
 xdata = pkgtype=pkg
 pkgver = 0.1.0-1
-pkgdesc = Sandboxed Lua-scriptable desktop icons for CVH Linux
+pkgdesc = Sandboxed Lua-scriptable desktop icons for CodeVerse Linux
 url = https://github.com/codeversehub/cvh-linux
 builddate = 1770221578
 packager = Unknown Packager

--- a/pkgbuild/cvh-icons/pkg/cvh-icons/usr/share/cvh-icons/scripts/file.lua
+++ b/pkgbuild/cvh-icons/pkg/cvh-icons/usr/share/cvh-icons/scripts/file.lua
@@ -5,7 +5,7 @@ Icon = {
     -- Metadata
     name = "file",
     version = "1.0",
-    author = "CVH Linux",
+    author = "CodeVerse Linux",
 
     -- Size
     width = 64,

--- a/pkgbuild/cvh-icons/pkg/cvh-icons/usr/share/cvh-icons/scripts/folder.lua
+++ b/pkgbuild/cvh-icons/pkg/cvh-icons/usr/share/cvh-icons/scripts/folder.lua
@@ -5,7 +5,7 @@ Icon = {
     -- Metadata
     name = "folder",
     version = "1.0",
-    author = "CVH Linux",
+    author = "CodeVerse Linux",
 
     -- Size (set by daemon based on config)
     width = 64,

--- a/scripts/build-iso.sh
+++ b/scripts/build-iso.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# CVH Linux ISO Build Script
-# Builds a bootable live ISO of CVH Linux
+# CodeVerse Linux ISO Build Script
+# Builds a bootable live ISO of CodeVerse Linux
 
 set -euo pipefail
 
@@ -219,7 +219,7 @@ cleanup() {
 
 # Show usage
 usage() {
-    echo "CVH Linux ISO Build Script"
+    echo "CodeVerse Linux ISO Build Script"
     echo
     echo "Usage: $0 [OPTIONS]"
     echo
@@ -268,7 +268,7 @@ main() {
 
     echo
     echo "╔════════════════════════════════════════════╗"
-    echo "║       CVH Linux ISO Build Script           ║"
+    echo "║       CodeVerse Linux ISO Build Script           ║"
     echo "╚════════════════════════════════════════════╝"
     echo
 

--- a/scripts/build-packages.sh
+++ b/scripts/build-packages.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Build custom CVH Linux packages
+# Build custom CodeVerse Linux packages
 # Creates cvh-fuzzy, cvh-icons, and cvh-branding packages
 
 set -euo pipefail
@@ -163,11 +163,11 @@ create_fuzzy_pkgbuild() {
 
     # Use absolute path in PKGBUILD
     cat > "$PKGBUILD_DIR/cvh-fuzzy/PKGBUILD" <<EOF
-# Maintainer: CVH Linux Team
+# Maintainer: CodeVerse Linux Team
 pkgname=cvh-fuzzy
 pkgver=0.1.0
 pkgrel=1
-pkgdesc="Universal fuzzy finder for CVH Linux"
+pkgdesc="Universal fuzzy finder for CodeVerse Linux"
 arch=('x86_64')
 url="https://github.com/codeversehub/cvh-linux"
 license=('GPL3')
@@ -221,11 +221,11 @@ create_icons_pkgbuild() {
 
     # Use absolute path in PKGBUILD
     cat > "$PKGBUILD_DIR/cvh-icons/PKGBUILD" <<EOF
-# Maintainer: CVH Linux Team
+# Maintainer: CodeVerse Linux Team
 pkgname=cvh-icons
 pkgver=0.1.0
 pkgrel=1
-pkgdesc="Sandboxed Lua-scriptable desktop icons for CVH Linux"
+pkgdesc="Sandboxed Lua-scriptable desktop icons for CodeVerse Linux"
 arch=('x86_64')
 url="https://github.com/codeversehub/cvh-linux"
 license=('GPL3')
@@ -278,11 +278,11 @@ create_branding_pkgbuild() {
     mkdir -p "$PKGBUILD_DIR/cvh-branding"
 
     cat > "$PKGBUILD_DIR/cvh-branding/PKGBUILD" <<EOF
-# Maintainer: CVH Linux Team
+# Maintainer: CodeVerse Linux Team
 pkgname=cvh-branding
 pkgver=0.1.0
 pkgrel=1
-pkgdesc="CVH Linux branding, GRUB theme, and default configurations"
+pkgdesc="CodeVerse Linux branding, GRUB theme, and default configurations"
 arch=('any')
 url="https://github.com/codeversehub/cvh-linux"
 license=('GPL3')
@@ -294,7 +294,7 @@ _cvh_root="$PROJECT_ROOT"
 package() {
     # MOTD - welcome message
     install -Dm644 /dev/stdin "\$pkgdir/etc/motd" <<'MOTDEOF'
-Welcome to CVH Linux!
+Welcome to CodeVerse Linux!
 
 Quick Start:
   - Mod+Return    Open terminal
@@ -306,10 +306,10 @@ Quick Start:
 For more info: https://github.com/codeversehub/cvh-linux
 MOTDEOF
 
-    # CVH Linux info file
+    # CodeVerse Linux info file
     install -Dm644 /dev/stdin "\$pkgdir/usr/share/cvh-linux/info" <<'INFOEOF'
-NAME="CVH Linux"
-PRETTY_NAME="CVH Linux"
+NAME="CodeVerse Linux"
+PRETTY_NAME="CodeVerse Linux"
 ID=cvh
 VERSION_ID=0.1
 HOME_URL="https://codeversehub.dev"
@@ -466,7 +466,7 @@ update_repo_db() {
 main() {
     echo
     echo "╔════════════════════════════════════════════╗"
-    echo "║     CVH Linux Package Build Script         ║"
+    echo "║     CodeVerse Linux Package Build Script         ║"
     echo "╚════════════════════════════════════════════╝"
     echo
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# CVH Linux Installer
-# Run from live environment to install CVH Linux to disk
+# CodeVerse Linux Installer
+# Run from live environment to install CodeVerse Linux to disk
 
 # Colors
 RED='\033[0;31m'
@@ -567,7 +567,7 @@ EOF
 # Configure Ly display manager
 mkdir -p /etc/ly
 cat > /etc/ly/config.ini << 'LY_EOF'
-# CVH Linux Ly Configuration
+# CodeVerse Linux Ly Configuration
 
 animation = 0
 hide_borders = 0
@@ -611,8 +611,8 @@ fi
 
 # Create os-release for proper branding (GRUB uses this)
 cat > /etc/os-release << EOF
-NAME="CVH Linux"
-PRETTY_NAME="CVH Linux"
+NAME="CodeVerse Linux"
+PRETTY_NAME="CodeVerse Linux"
 ID=cvh
 ID_LIKE=arch
 BUILD_ID=rolling
@@ -623,8 +623,8 @@ LOGO=cvh-logo
 EOF
 
 # Set GRUB distributor name
-sed -i 's/^GRUB_DISTRIBUTOR=.*/GRUB_DISTRIBUTOR="CVH Linux"/' /etc/default/grub 2>/dev/null || \
-    echo 'GRUB_DISTRIBUTOR="CVH Linux"' >> /etc/default/grub
+sed -i 's/^GRUB_DISTRIBUTOR=.*/GRUB_DISTRIBUTOR="CodeVerse Linux"/' /etc/default/grub 2>/dev/null || \
+    echo 'GRUB_DISTRIBUTOR="CodeVerse Linux"' >> /etc/default/grub
 
 # Ensure zsh is in /etc/shells
 echo "/usr/bin/zsh" >> /etc/shells
@@ -710,7 +710,7 @@ NIRI_EOF
 elif [[ "$COMPOSITOR" == "hyprland" ]]; then
     su - $USERNAME -c 'mkdir -p ~/.config/hypr'
     cat > /home/$USERNAME/.config/hypr/hyprland.conf << 'HYPR_EOF'
-# CVH Linux Hyprland Configuration
+# CodeVerse Linux Hyprland Configuration
 
 monitor=,preferred,auto,auto
 
@@ -1045,7 +1045,7 @@ CONFIGURE_SCRIPT
     echo -e "  ${BLUE}●${NC} Creating package mirrorlist..."
     mkdir -p /mnt/etc/pacman.d
     cat > /mnt/etc/pacman.d/mirrorlist << 'MIRRORLIST_EOF'
-# Arch Linux mirrorlist - CVH Linux
+# Arch Linux mirrorlist - CodeVerse Linux
 # Israeli mirrors
 Server = https://mirror.isoc.org.il/pub/archlinux/$repo/os/$arch
 Server = https://archlinux.mivzakim.net/$repo/os/$arch

--- a/src/cvh-fuzzy/Cargo.toml
+++ b/src/cvh-fuzzy/Cargo.toml
@@ -2,8 +2,8 @@
 name = "cvh-fuzzy"
 version = "0.1.0"
 edition = "2021"
-authors = ["CVH Linux Team"]
-description = "Universal fuzzy finder for CVH Linux - files, apps, and commands"
+authors = ["CodeVerse Linux Team"]
+description = "Universal fuzzy finder for CodeVerse Linux - files, apps, and commands"
 license = "GPL-3.0"
 repository = "https://github.com/codeversehub/cvh-linux"
 

--- a/src/cvh-fuzzy/src/main.rs
+++ b/src/cvh-fuzzy/src/main.rs
@@ -1,4 +1,4 @@
-//! CVH Fuzzy - Universal fuzzy finder for CVH Linux
+//! CVH Fuzzy - Universal fuzzy finder for CodeVerse Linux
 //!
 //! A fast, all-in-one fuzzy finder for:
 //! - Files and directories
@@ -39,7 +39,7 @@ mod matcher;
 /// CVH Fuzzy - Universal fuzzy finder
 #[derive(Parser, Debug)]
 #[command(name = "cvh-fuzzy")]
-#[command(author = "CVH Linux Team")]
+#[command(author = "CodeVerse Linux Team")]
 #[command(version = "0.1.0")]
 #[command(about = "Universal fuzzy finder for files, apps, and commands")]
 struct Args {

--- a/src/cvh-icons/Cargo.toml
+++ b/src/cvh-icons/Cargo.toml
@@ -2,8 +2,8 @@
 name = "cvh-icons"
 version = "0.1.0"
 edition = "2021"
-authors = ["CVH Linux Team"]
-description = "Sandboxed Lua-scriptable file/folder icon system for CVH Linux"
+authors = ["CodeVerse Linux Team"]
+description = "Sandboxed Lua-scriptable file/folder icon system for CodeVerse Linux"
 license = "GPL-3.0"
 repository = "https://github.com/codeversehub/cvh-linux"
 

--- a/src/cvh-icons/lua/widgets/file.lua
+++ b/src/cvh-icons/lua/widgets/file.lua
@@ -5,7 +5,7 @@ Icon = {
     -- Metadata
     name = "file",
     version = "1.0",
-    author = "CVH Linux",
+    author = "CodeVerse Linux",
 
     -- Size
     width = 64,

--- a/src/cvh-icons/lua/widgets/folder.lua
+++ b/src/cvh-icons/lua/widgets/folder.lua
@@ -5,7 +5,7 @@ Icon = {
     -- Metadata
     name = "folder",
     version = "1.0",
-    author = "CVH Linux",
+    author = "CodeVerse Linux",
 
     -- Size (set by daemon based on config)
     width = 64,

--- a/src/cvh-icons/src/main.rs
+++ b/src/cvh-icons/src/main.rs
@@ -20,7 +20,7 @@ mod wayland;
 /// CVH Icons - Desktop icon manager
 #[derive(Parser, Debug)]
 #[command(name = "cvh-icons")]
-#[command(author = "CVH Linux Team")]
+#[command(author = "CodeVerse Linux Team")]
 #[command(version = "0.1.0")]
 #[command(about = "Sandboxed Lua-scriptable desktop icons")]
 struct Args {


### PR DESCRIPTION
## Summary
This PR standardizes the project name to "CodeVerse Linux" across the entire repository to resolve naming inconsistencies, as requested in the linked issue.

## Changes
Closes #14
- Replaced all instances of "CVH Linux" (and other variations) with "CodeVerse Linux".
- Updated docstrings, documentation (README), and configuration files to reflect the standardized name.

## Testing
Since this is purely a text and naming standardization update, I did not build the ISO or boot a VM. I performed a global search to ensure all replacements were accurate and didn't break code syntax.
- [ ] Built ISO
- [ ] Booted in VM
- [ ] Ran installer (`cvh-install`)

## Checklist
- [x] Scope is focused (no unrelated changes)
- [x] Docs updated (if needed)
- [ ] Scripts/configs changed were tested