### PR TITLE
Docs: improve installation instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,22 +8,94 @@ CodeVerse Linux (CVH Linux) is a **community-driven, Arch-based Linux distributi
 - **Recommended for:** VM testing while the project is evolving
 - **Also intended for:** real hardware (use caution; the installer wipes the selected disk)
 
-## Install (from a built ISO)
+## Getting Started (Beginner-Friendly)
+ 
+This section walks you through everything from scratch. No prior Arch Linux or ISO experience needed.
+ 
+### What is an ISO?
+ 
+An ISO file is a complete, bootable disk image — think of it as a virtual CD/USB that contains a live operating system. To use CVH Linux, you first need to *build* this ISO file from the source code in this repo, then either:
+- Flash it to a USB drive and boot your computer from it, **or**
+- Attach it to a Virtual Machine (VM) like VirtualBox or QEMU
 
-1. Build the ISO (see [docs/BUILD.md](docs/BUILD.md)).
-2. Write the ISO to USB (or attach it to your VM) and boot it.
-3. In the live environment, run the installer:
-   - `sudo cvh-install`
+### Step 1: Set Up Your Build Machine
+ 
+> **What this means:** You need an existing Arch-based Linux system (like Arch Linux, EndeavourOS, or Manjaro) to build the ISO. Building the ISO is currently supported only on Arch-based systems.
+ 
+If you don’t have an Arch-based system, you can use a virtual machine (VM) with Arch Linux for building.
+ 
+Make sure the following tools are installed on your build machine:
+ 
+ ```bash
+sudo pacman -S archiso git
+```
 
-The installer is interactive and will partition/format the chosen disk.
+### Step 2: Clone This Repository
+ 
+ ```bash
+git clone https://github.com/TheCodeVerseHub/CodeVerseLinuxDistro.git
+cd CodeVerseLinuxDistro
+```
 
-## Build ISO (quick)
+### Step 3: Build the ISO
+ 
+Run the build script:
+ ```bash
+./scripts/build-iso.sh
+ ```
 
-On an Arch-based build host:
+This will take several minutes — it downloads packages and assembles the full system image. When it finishes, you'll find the `.iso` file inside the `out/` folder.
+ 
+> For more detailed build options and troubleshooting, see [docs/BUILD.md](docs/BUILD.md).
 
-- `./scripts/build-iso.sh`
+### Step 4: Boot the ISO
+ This will start a live system that runs directly from the ISO without installing anything.
+You have two options depending on whether you're using a real machine or a VM.
+ 
+#### Option A: Real Hardware (USB Drive)
+ 
+>  **Warning:** The installer will wipe the disk you select. Back up any important data first.
 
-Outputs land in `out/` by default. Full details: [docs/BUILD.md](docs/BUILD.md).
+Flash the ISO to a USB drive. Replace `/dev/sdX` with your actual USB device (use `lsblk` to find it):
+ 
+ ```bash
+sudo dd if=out/codeverse-linux-*.iso of=/dev/sdX bs=4M status=progress oflag=sync
+```
+ 
+Then plug the USB into your target machine and boot from it (usually by pressing F2, F12, or Del during startup to open the boot menu).
+ 
+#### Option B: Virtual Machine — VirtualBox
+ 
+1. Open VirtualBox and click **New**
+2. Set type to **Linux**, version to **Arch Linux (64-bit)**
+3. Allocate at least **2 GB RAM** and **20 GB disk space**
+4. Under **Settings → Storage**, attach the `.iso` file as an optical drive
+5. Start the VM — it will boot directly into the CVH Linux live environment
+ 
+#### Option C: Virtual Machine — QEMU
+ 
+```bash
+qemu-system-x86_64 \
+  -m 2G \
+  -cdrom out/codeverse-linux-*.iso \
+  -boot d \
+  -enable-kvm
+```
+ 
+> Remove `-enable-kvm` if your system doesn't support KVM (you'll see an error if so).
+ 
+ ### Step 5: Run the Installer
+ 
+Once booted into the live environment, open a terminal and run:
+ 
+ ```bash
+sudo cvh-install
+ ```
+
+The installer is interactive — it will ask you which disk to install to and walk you through the setup. Follow the on-screen prompts.
+ 
+>**Reminder:** The installer will partition and format the disk you choose. Make sure you select the correct one.
+ 
 
 ## Screenshots
 
@@ -36,12 +108,14 @@ Add screenshots to this section as the UI stabilizes.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for environment setup, testing, and PR guidelines.
 
-## Repo layout (high level)
-
-- `iso/`: ArchISO profile (packages list, `airootfs/`, bootloader config)
-- `scripts/`: build ISO, build packages, legacy/standalone installer script
-- `configs/`: GRUB theme + user setup configs (niri, waybar, rofi, etc.)
-- `src/` + `pkgbuild/` + `repo/`: custom packages and local pacman repo artifacts
+## Repo Layout (High Level)
+ 
+| Path | Description |
+|---|---|
+| `iso/` | ArchISO profile (packages list, `airootfs/`, bootloader config) |
+| `scripts/` | Build ISO, build packages, legacy/standalone installer script |
+| `configs/` | GRUB theme + user setup configs (niri, waybar, rofi, etc.) |
+| `src/` + `pkgbuild/` + `repo/` | Custom packages and local pacman repo artifacts |
 
 ## License
 


### PR DESCRIPTION
Fixes #10 
## Summary

Improves the installation section of `README.md` to be beginner-friendly, as described in the issue.

## Changes
- Added a **"What is an ISO?"** explanation so users understand what they're building before they start
- Rewrote the install steps with **"What this means:"** callouts to explain the why behind each command
- Added Step 1 for setting up the build machine with the exact `pacman` command needed
- Added Step 2 with the correct clone URL and `cd` command
- Expanded boot instructions into three clear options: USB (real hardware), VirtualBox (with GUI walkthrough), and QEMU (with command)
- Converted the repo layout section from bullets to a **table** for easier scanning


## Testing

<!-- How did you test this? -->
Reviewed against the acceptance criteria in the issue:
- [x] Each step is clearly explained
- [x] Instructions are beginner-friendly
- [x] No assumptions about prior knowledge
