### PR TITLE
Add CONFIGS.md documentation

### DIFF
--- a/docs/CONFIGS.md
+++ b/docs/CONFIGS.md
@@ -1,0 +1,19 @@
+# Configuration Files
+
+This document explains the configuration files used in the project.
+
+## configs/
+
+The `configs/` directory contains important system configuration files used by the distribution.
+
+### grub/themes/
+
+This folder contains GRUB bootloader themes.
+
+GRUB is responsible for the boot menu when the system starts. The themes in this folder control how the boot menu looks, including colours, layout, and fonts.
+
+### setup-configs/
+
+This folder contains setup-related configuration files used during system setup or installation.
+
+These configurations help define how the system is prepared, installed, or initialised.


### PR DESCRIPTION
This PR adds documentation for configuration files in the configs directory.

It explains the purpose of the grub/themes and setup-configs folders in a beginner friendly way.